### PR TITLE
Refactor CustomNewsProvider and add OAuth2 project support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -467,3 +467,4 @@ $RECYCLE.BIN/
 /tests/Gml.Api.Tests/.env
 /src/Gml.Web.Api/src/Gml.Web.Api/private.key
 /src/Gml.Web.Api/src/Gml.Web.Api/public.key
+/src/Gml.Web.Api/src/Gml.Web.Api/BugStorage.json

--- a/Gml.Backend.sln
+++ b/Gml.Backend.sln
@@ -87,6 +87,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gml.Web.Api.Plugins.Templat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gml.Web.Api.EndpointSDK", "src\Gml.Web.Api\src\plugins\Gml.Web.Api.EndpointSDK\Gml.Web.Api.EndpointSDK.csproj", "{3F58FC4F-5ED3-4B63-8657-B2DB76711F0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gml.Web.Api.OAuth2", "src\Gml.Web.Api\src\plugins\commercial\Gml.Web.Api.OAuth2\Gml.Web.Api.OAuth2.csproj", "{9B3A8084-4E03-4EF0-93F8-4F366ED80766}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +167,10 @@ Global
 		{3F58FC4F-5ED3-4B63-8657-B2DB76711F0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F58FC4F-5ED3-4B63-8657-B2DB76711F0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F58FC4F-5ED3-4B63-8657-B2DB76711F0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B3A8084-4E03-4EF0-93F8-4F366ED80766}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B3A8084-4E03-4EF0-93F8-4F366ED80766}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B3A8084-4E03-4EF0-93F8-4F366ED80766}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B3A8084-4E03-4EF0-93F8-4F366ED80766}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,5 +201,6 @@ Global
 		{71792E05-B97A-4861-87D4-2B176A004FA3} = {079E0363-DE4D-43DD-86BB-99D921E6D2EE}
 		{E4E57BD8-E9B3-45B1-94C5-C0E49B57229C} = {14CCAE0C-9728-4937-B902-4DC2C0B0BF69}
 		{3F58FC4F-5ED3-4B63-8657-B2DB76711F0F} = {D88B8B9C-307C-4A15-BCED-6AF8CD79B688}
+		{9B3A8084-4E03-4EF0-93F8-4F366ED80766} = {3A539442-8520-4AC1-9AF6-26FC960C2E9C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Renamed variables and parameters for consistency across the codebase (e.g., `_url` to `Url`, and `number` to `count`). Added `Gml.Web.Api.OAuth2` project to the solution. Updated `.gitignore` to include `BugStorage.json`.